### PR TITLE
Make FailedPushTicket properties public

### DIFF
--- a/src/PushTicket/FailedPushTicket.php
+++ b/src/PushTicket/FailedPushTicket.php
@@ -7,7 +7,7 @@ use Dru1x\ExpoPush\Support\PushStatus;
 
 final readonly class FailedPushTicket extends PushTicket
 {
-    public function __construct(PushToken $token, protected string $message, protected PushTicketDetails $details)
+    public function __construct(PushToken $token, public string $message, public PushTicketDetails $details)
     {
         parent::__construct($token, PushStatus::Error);
     }

--- a/tests/Unit/PushTicket/FailedPushTicketTest.php
+++ b/tests/Unit/PushTicket/FailedPushTicketTest.php
@@ -6,11 +6,32 @@ use Dru1x\ExpoPush\PushTicket\FailedPushTicket;
 use Dru1x\ExpoPush\PushTicket\PushTicketDetails;
 use Dru1x\ExpoPush\PushTicket\PushTicketErrorCode;
 use Dru1x\ExpoPush\PushToken\PushToken;
+use Dru1x\ExpoPush\Support\PushStatus;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class FailedPushTicketTest extends TestCase
 {
+    #[Test]
+    public function properties_are_accessible(): void
+    {
+        $token = new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]');
+
+        $message = '"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]" is not a registered push notification recipient';
+
+        $details = new PushTicketDetails(
+            error: PushTicketErrorCode::DeviceNotRegistered,
+            expoPushToken: $token,
+        );
+
+        $ticket = new FailedPushTicket($token, $message, $details);
+
+        $this->assertEquals($token, $ticket->token);
+        $this->assertEquals($message, $ticket->message);
+        $this->assertEquals($details, $ticket->details);
+        $this->assertEquals(PushStatus::Error, $ticket->status);
+    }
+
     #[Test]
     public function json_encode_returns_value(): void
     {

--- a/tests/Unit/PushTicket/SuccessfulPushReceiptTest.php
+++ b/tests/Unit/PushTicket/SuccessfulPushReceiptTest.php
@@ -3,16 +3,28 @@
 namespace Dru1x\ExpoPush\Tests\Unit\PushTicket;
 
 use Dru1x\ExpoPush\PushReceipt\SuccessfulPushReceipt;
+use Dru1x\ExpoPush\Support\PushStatus;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class SuccessfulPushReceiptTest extends TestCase
 {
     #[Test]
+    public function properties_are_accessible(): void
+    {
+        $id = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
+
+        $receipt = new SuccessfulPushReceipt($id);
+
+        $this->assertEquals($id, $receipt->id);
+        $this->assertEquals(PushStatus::Ok, $receipt->status);
+    }
+
+    #[Test]
     public function json_encode_returns_value(): void
     {
         $receipt = new SuccessfulPushReceipt(
-            id:'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
         );
 
         $expectedJson = <<<JSON
@@ -29,7 +41,7 @@ JSON;
     public function to_json_returns_value(): void
     {
         $receipt = new SuccessfulPushReceipt(
-            id:'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
         );
 
         $expectedJson = <<<JSON

--- a/tests/Unit/PushTicket/SuccessfulPushTicketTest.php
+++ b/tests/Unit/PushTicket/SuccessfulPushTicketTest.php
@@ -4,11 +4,25 @@ namespace Dru1x\ExpoPush\Tests\Unit\PushTicket;
 
 use Dru1x\ExpoPush\PushTicket\SuccessfulPushTicket;
 use Dru1x\ExpoPush\PushToken\PushToken;
+use Dru1x\ExpoPush\Support\PushStatus;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class SuccessfulPushTicketTest extends TestCase
 {
+    #[Test]
+    public function properties_are_accessible(): void
+    {
+        $token = new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]');
+        $receiptId = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
+
+        $ticket = new SuccessfulPushTicket($token, $receiptId);
+
+        $this->assertEquals($token, $ticket->token);
+        $this->assertEquals($receiptId, $ticket->receiptId);
+        $this->assertEquals(PushStatus::Ok, $ticket->status);
+    }
+
     #[Test]
     public function json_encode_returns_value(): void
     {


### PR DESCRIPTION
## Summary
Fixes a bug where properties specific to `FailedPushTicket` were inaccessible.

## Changes
- Changed `FailedPushTicket::$message` visibility to `public`
- Changed `FailedPushTicket::$details` visibility to `public`

## Testing
- Added test cases to check for accessible properties in `SuccessfulPushTicket`, and `FailedPushTicket`

## Related Issues
Fixes #31 