### PR TITLE
Add filter method to Collection classes

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -112,6 +112,20 @@ abstract class Collection implements Countable, IteratorAggregate, JsonSerializa
     }
 
     /**
+     * Filter this collection using the given callback
+     *
+     * @param callable(TValue $item, TKey $key): bool $callback
+     *
+     * @return static
+     */
+    public function filter(callable $callback): static
+    {
+        return new static(
+            ...array_filter($this->items, $callback, ARRAY_FILTER_USE_BOTH)
+        );
+    }
+
+    /**
      * Merge a set of collections into a single collection
      *
      * @param static<TKey, TValue> ...$collections

--- a/tests/Unit/PushError/PushErrorCollectionTest.php
+++ b/tests/Unit/PushError/PushErrorCollectionTest.php
@@ -153,6 +153,37 @@ class PushErrorCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushErrorCollection(
+            new PushError(code: PushErrorCode::Failed, message: 'Push notifications failed to send'),
+            new PushError(code: PushErrorCode::Unknown, message: 'Unknown error'),
+            new PushError(code: PushErrorCode::Unauthorized, message: 'Invalid authentication token'),
+            new PushError(code: PushErrorCode::PushTooManyNotifications, message: 'Too many notifications'),
+        );
+
+        $filteredCollection = $collection->filter(fn(PushError $error) => $error->code !== PushErrorCode::Failed);
+
+        $this->assertCount(3, $filteredCollection);
+        $this->assertNotEquals(PushErrorCode::Failed, $filteredCollection->get(0)->code);
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushErrorCollection(
+            new PushError(code: PushErrorCode::Failed, message: 'Push notifications failed to send'),
+            new PushError(code: PushErrorCode::Unknown, message: 'Unknown error'),
+            new PushError(code: PushErrorCode::Unauthorized, message: 'Invalid authentication token'),
+            new PushError(code: PushErrorCode::PushTooManyNotifications, message: 'Too many notifications'),
+        );
+
+        $collection->filter(fn(PushError $error) => $error->code !== PushErrorCode::Failed);
+
+        $this->assertCount(4, $collection);
+    }
+
+    #[Test]
     public function values_returns_collection_with_consecutive_keys(): void
     {
         $collection = new PushErrorCollection(

--- a/tests/Unit/PushMessage/PushMessageCollectionTest.php
+++ b/tests/Unit/PushMessage/PushMessageCollectionTest.php
@@ -158,6 +158,43 @@ class PushMessageCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushMessageCollection(
+            new PushMessage(to: new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'), title: 'Test Notification 1'),
+            new PushMessage(to: new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'), title: 'Test Notification 2'),
+            new PushMessage(to: new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'), title: 'Test Notification 3'),
+            new PushMessage(to: new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'), title: 'Test Notification 4'),
+            new PushMessage(to: new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'), title: 'Test Notification 5'),
+        );
+
+        $filteredCollection = $collection->filter(
+            fn(PushMessage $message) => $message->to->value !== 'ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'
+        );
+
+        $this->assertCount(4, $filteredCollection);
+        $this->assertNotEquals('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]', $filteredCollection->get(3)->to);
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushMessageCollection(
+            new PushMessage(to: new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'), title: 'Test Notification 1'),
+            new PushMessage(to: new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'), title: 'Test Notification 2'),
+            new PushMessage(to: new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'), title: 'Test Notification 3'),
+            new PushMessage(to: new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'), title: 'Test Notification 4'),
+            new PushMessage(to: new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'), title: 'Test Notification 5'),
+        );
+
+        $collection->filter(
+            fn(PushMessage $message) => $message->to->value !== 'ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'
+        );
+
+        $this->assertCount(5, $collection);
+    }
+
+    #[Test]
     public function get_push_tokens_returns_correctly_ordered_push_token_collection(): void
     {
         $collection = new PushMessageCollection(

--- a/tests/Unit/PushReceipt/PushReceiptCollectionTest.php
+++ b/tests/Unit/PushReceipt/PushReceiptCollectionTest.php
@@ -182,6 +182,45 @@ class PushReceiptCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushReceiptCollection(
+            new SuccessfulPushReceipt(id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'),
+            new SuccessfulPushReceipt(id: 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY'),
+            new SuccessfulPushReceipt(id: 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ'),
+            new SuccessfulPushReceipt(id: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+            new SuccessfulPushReceipt(id: 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+            new SuccessfulPushReceipt(id: 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
+        );
+
+        $filteredCollection = $collection->filter(
+            fn(SuccessfulPushReceipt $receipt) => $receipt->id !== 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+        );
+
+        $this->assertCount(5, $filteredCollection);
+        $this->assertNotEquals('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', $filteredCollection->get(0)->id);
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushReceiptCollection(
+            new SuccessfulPushReceipt(id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'),
+            new SuccessfulPushReceipt(id: 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY'),
+            new SuccessfulPushReceipt(id: 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ'),
+            new SuccessfulPushReceipt(id: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'),
+            new SuccessfulPushReceipt(id: 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB'),
+            new SuccessfulPushReceipt(id: 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC'),
+        );
+
+        $collection->filter(
+            fn(SuccessfulPushReceipt $receipt) => $receipt->id !== 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+        );
+
+        $this->assertCount(6, $collection);
+    }
+
+    #[Test]
     public function values_returns_collection_with_consecutive_keys(): void
     {
         $collection = new PushReceiptCollection(

--- a/tests/Unit/PushReceipt/PushReceiptIdCollectionTest.php
+++ b/tests/Unit/PushReceipt/PushReceiptIdCollectionTest.php
@@ -143,6 +143,45 @@ class PushReceiptIdCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushReceiptIdCollection(
+            'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY',
+            'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ',
+            'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC',
+        );
+
+        $filteredCollection = $collection->filter(
+            fn(string $receiptId) => $receiptId !== 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY'
+        );
+
+        $this->assertCount(5, $filteredCollection);
+        $this->assertNotEquals('YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY', $filteredCollection->get(1));
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushReceiptIdCollection(
+            'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY',
+            'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ',
+            'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC',
+        );
+
+        $collection->filter(
+            fn(string $receiptId) => $receiptId !== 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY'
+        );
+
+        $this->assertCount(6, $collection);
+    }
+
+    #[Test]
     public function values_returns_collection_with_consecutive_keys(): void
     {
         $collection = new PushReceiptIdCollection(

--- a/tests/Unit/PushTicket/PushTicketCollectionTest.php
+++ b/tests/Unit/PushTicket/PushTicketCollectionTest.php
@@ -294,6 +294,82 @@ class PushTicketCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushTicketCollection(
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'),
+                receiptId: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'),
+                receiptId: 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'),
+                receiptId: 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'),
+                receiptId: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'),
+                receiptId: 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[cccccccccccccccccccccc]'),
+                receiptId: 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC',
+            ),
+        );
+
+        /** @var Collection<int, SuccessfulPushTicket> $filteredCollection */
+        $filteredCollection = $collection->filter(
+            fn(SuccessfulPushTicket $ticket) => $ticket->receiptId !== 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ'
+        );
+
+        $this->assertCount(5, $filteredCollection);
+        $this->assertNotEquals('ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ', $filteredCollection->get(2)->receiptId);
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushTicketCollection(
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'),
+                receiptId: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'),
+                receiptId: 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'),
+                receiptId: 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'),
+                receiptId: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'),
+                receiptId: 'BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB',
+            ),
+            new SuccessfulPushTicket(
+                token: new PushToken('ExponentPushToken[cccccccccccccccccccccc]'),
+                receiptId: 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC',
+            ),
+        );
+
+        $collection->filter(
+            fn(SuccessfulPushTicket $ticket) => $ticket->receiptId !== 'ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ'
+        );
+
+        $this->assertCount(6, $collection);
+    }
+
+    #[Test]
     public function values_returns_collection_with_consecutive_keys(): void
     {
         $collection = new PushTicketCollection(

--- a/tests/Unit/PushToken/PushTokenCollectionTest.php
+++ b/tests/Unit/PushToken/PushTokenCollectionTest.php
@@ -152,6 +152,45 @@ class PushTokenCollectionTest extends TestCase
     }
 
     #[Test]
+    public function filter_returns_correctly_filtered_collection(): void
+    {
+        $collection = new PushTokenCollection(
+            new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'),
+            new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'),
+            new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'),
+            new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'),
+            new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'),
+            new PushToken('ExponentPushToken[cccccccccccccccccccccc]'),
+        );
+
+        $filteredCollection = $collection->filter(
+            fn(PushToken $token) => $token->value !== 'ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'
+        );
+
+        $this->assertCount(5, $filteredCollection);
+        $this->assertNotEquals('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]', $filteredCollection->get(4)->value);
+    }
+
+    #[Test]
+    public function filter_does_not_affect_original_collection(): void
+    {
+        $collection = new PushTokenCollection(
+            new PushToken('ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'),
+            new PushToken('ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'),
+            new PushToken('ExponentPushToken[zzzzzzzzzzzzzzzzzzzzzz]'),
+            new PushToken('ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]'),
+            new PushToken('ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'),
+            new PushToken('ExponentPushToken[cccccccccccccccccccccc]'),
+        );
+
+        $collection->filter(
+            fn(PushToken $token) => $token->value !== 'ExponentPushToken[bbbbbbbbbbbbbbbbbbbbbb]'
+        );
+
+        $this->assertCount(6, $collection);
+    }
+
+    #[Test]
     public function values_returns_collection_with_consecutive_keys(): void
     {
         $collection = new PushTokenCollection(


### PR DESCRIPTION
## Summary
Adds a `filter(callable $callback)` method to all collections, to make it simpler to reduce collections based on filtering criteria.

## Changes 
- Added `filter(callable $callback)` to `Support/Collection`

## Testing
- Added unit tests to all collection-related test cases

## Related Issues
Closes #34