### PR TITLE
Remove `final` keyword from ExpoPush

### DIFF
--- a/src/ExpoPush.php
+++ b/src/ExpoPush.php
@@ -19,7 +19,7 @@ use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Pool;
 use Saloon\Http\Response;
 
-final class ExpoPush
+class ExpoPush
 {
     protected ExpoPushConnector $connector;
 


### PR DESCRIPTION
## Summary
Removes the `final` keyword from `ExpoPush` so it can be doubled in tests.

## Changes
- `ExpoPush` made non-final

## Related Issues
Fixes #36 