### PR TITLE
Update minimum saloon version to address 3x CVE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": ">=8.2",
     "ext-json": "*",
     "ext-zlib": "*",
-    "saloonphp/saloon": "3.11",
+    "saloonphp/saloon": "^4.0",
     "saloonphp/rate-limit-plugin": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary
Update minimum version of Saloon to 4.0.0 to address [CVE-2026-33942](https://github.com/saloonphp/saloon/security/advisories/GHSA-rf88-776r-rcq9), [CVE-2026-33182 ](https://github.com/saloonphp/saloon/security/advisories/GHSA-c83f-3xp6-hfcp) and [CVE-2026-33183 ](https://github.com/saloonphp/saloon/security/advisories/GHSA-f7xc-5852-fj99).

## Related Issues
Closes #50 